### PR TITLE
Fix posthtml-render import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const { Transformer } = require('@parcel/plugin')
 const parser = require('posthtml-parser').default
 const nullthrows = require('nullthrows')
-const render = require('posthtml-render')
+const { render } = require('posthtml-render')
 const semver = require('semver')
 const PostHTML = require('posthtml')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.1",
         "posthtml-parser": "^0.9.0",
-        "posthtml-render": "^2.0.3",
+        "posthtml-render": "^3.0.0",
         "semver": "^7.3.5"
       },
       "devDependencies": {
@@ -35,7 +35,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.0.0-beta.3.1"
+        "parcel": "^2.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1693,18 +1693,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@parcel/transformer-html/node_modules/posthtml-render": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-      "dev": true,
-      "dependencies": {
-        "is-json": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@parcel/transformer-html/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -1898,18 +1886,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@parcel/transformer-posthtml/node_modules/posthtml-render": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-      "dev": true,
-      "dependencies": {
-        "is-json": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@parcel/transformer-posthtml/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -2016,18 +1992,6 @@
       "dev": true,
       "dependencies": {
         "htmlparser2": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@parcel/transformer-svg/node_modules/posthtml-render": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-      "dev": true,
-      "dependencies": {
-        "is-json": "^2.0.1"
       },
       "engines": {
         "node": ">=12"
@@ -9100,11 +9064,14 @@
       }
     },
     "node_modules/posthtml-render": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-2.0.3.tgz",
-      "integrity": "sha512-5DUBp+gDFNkBzHeSQp0UbuIGpD5HxfhW9mDmSB1eO7zZ26bX/XuYA16t+cosW+HoSzcF3FoMDRy5fWbg5G3c5Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+      "dependencies": {
+        "is-json": "^2.0.1"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/posthtml/node_modules/entities": {
@@ -9142,17 +9109,6 @@
       "integrity": "sha512-i7w2QEHqiGtsvNNPty0Mt/+ERch7wkgnFh3+JnBI2VgDbGlBqKW9eDVd3ENUhE1ujGFe3e3E/odf7eKhvLUyDg==",
       "dependencies": {
         "htmlparser2": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/posthtml/node_modules/posthtml-render": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-      "dependencies": {
-        "is-json": "^2.0.1"
       },
       "engines": {
         "node": ">=12"
@@ -12304,15 +12260,6 @@
             "htmlparser2": "^7.1.1"
           }
         },
-        "posthtml-render": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-          "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-          "dev": true,
-          "requires": {
-            "is-json": "^2.0.1"
-          }
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -12447,15 +12394,6 @@
             "htmlparser2": "^7.1.1"
           }
         },
-        "posthtml-render": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-          "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-          "dev": true,
-          "requires": {
-            "is-json": "^2.0.1"
-          }
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -12524,15 +12462,6 @@
           "dev": true,
           "requires": {
             "htmlparser2": "^7.1.1"
-          }
-        },
-        "posthtml-render": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-          "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-          "dev": true,
-          "requires": {
-            "is-json": "^2.0.1"
           }
         },
         "semver": {
@@ -17044,7 +16973,7 @@
     "parcel-transformer-html-datasrc": {
       "version": "file:",
       "requires": {
-        "@parcel/plugin": "^2.0.0-alpha.3",
+        "@parcel/plugin": "^2.0.0",
         "chai": "^4.3.4",
         "coveralls": "^3.1.0",
         "eslint": "^7.28.0",
@@ -17061,7 +16990,7 @@
         "parcel-transformer-html-datasrc": "file:",
         "posthtml": "^0.16.1",
         "posthtml-parser": "^0.9.0",
-        "posthtml-render": "^2.0.3",
+        "posthtml-render": "^3.0.0",
         "prettier": "^2.3.1",
         "semver": "^7.3.5"
       },
@@ -18256,15 +18185,6 @@
                 "htmlparser2": "^7.1.1"
               }
             },
-            "posthtml-render": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-              "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-              "dev": true,
-              "requires": {
-                "is-json": "^2.0.1"
-              }
-            },
             "semver": {
               "version": "5.7.1",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -18399,15 +18319,6 @@
                 "htmlparser2": "^7.1.1"
               }
             },
-            "posthtml-render": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-              "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-              "dev": true,
-              "requires": {
-                "is-json": "^2.0.1"
-              }
-            },
             "semver": {
               "version": "5.7.1",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -18476,15 +18387,6 @@
               "dev": true,
               "requires": {
                 "htmlparser2": "^7.1.1"
-              }
-            },
-            "posthtml-render": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-              "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-              "dev": true,
-              "requires": {
-                "is-json": "^2.0.1"
               }
             },
             "semver": {
@@ -23912,14 +23814,6 @@
               "requires": {
                 "htmlparser2": "^7.1.1"
               }
-            },
-            "posthtml-render": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-              "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-              "requires": {
-                "is-json": "^2.0.1"
-              }
             }
           }
         },
@@ -23932,9 +23826,12 @@
           }
         },
         "posthtml-render": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-2.0.3.tgz",
-          "integrity": "sha512-5DUBp+gDFNkBzHeSQp0UbuIGpD5HxfhW9mDmSB1eO7zZ26bX/XuYA16t+cosW+HoSzcF3FoMDRy5fWbg5G3c5Q=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+          "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+          "requires": {
+            "is-json": "^2.0.1"
+          }
         },
         "prelude-ls": {
           "version": "1.2.1",
@@ -26386,14 +26283,6 @@
           "requires": {
             "htmlparser2": "^7.1.1"
           }
-        },
-        "posthtml-render": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-          "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-          "requires": {
-            "is-json": "^2.0.1"
-          }
         }
       }
     },
@@ -26406,9 +26295,12 @@
       }
     },
     "posthtml-render": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-2.0.3.tgz",
-      "integrity": "sha512-5DUBp+gDFNkBzHeSQp0UbuIGpD5HxfhW9mDmSB1eO7zZ26bX/XuYA16t+cosW+HoSzcF3FoMDRy5fWbg5G3c5Q=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+      "requires": {
+        "is-json": "^2.0.1"
+      }
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "nullthrows": "^1.1.1",
     "posthtml": "^0.16.1",
     "posthtml-parser": "^0.9.0",
-    "posthtml-render": "^2.0.3",
+    "posthtml-render": "^3.0.0",
     "semver": "^7.3.5"
   }
 }


### PR DESCRIPTION
Closes https://github.com/moritzlaube/parcel-transformer-html-datasrc/issues/1, though this really only occurs with a wrong parcelrc config (if the default Parcel HTML transformers aren't included).

`render` was undefined, because posthtml-render@2.0.0 exported `{ default: theActualRenderFunction }`. 