### PR TITLE
feat: added support for source tag (required in picture)

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = new Transformer({
         return node
       }
 
-      if (tag === 'img' && attrs['data-src'] != null) {
+      if ((tag === 'img' || tag === 'source') != null) {
         attrs['data-src'] = asset.addURLDependency(attrs['data-src'], {})
         isDirty = true
       }

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = new Transformer({
         isDirty = true
       }
 
-      if (tag === 'img' && attrs['data-srcset'] != null) {
+      if ((tag === 'img' || tag === 'source') && attrs['data-srcset'] != null) {
         const srcsets = attrs['data-srcset'].split(',').map(item => {
           const [url, width] = item.trim().split(' ')
           return `${asset.addURLDependency(url)} ${width}`


### PR DESCRIPTION
Currently your plugin only supports `img` elements with a `data-srcset`, this pull request adds support for the `data-srcset` attribute on a `source` field, which is required in a `picture`, e.g:

```
<picture>
  <source data-srcset="./images/Image.webp" type="image/webp">
  <source data-srcset="./images/Image.jpg" type="image/jpeg"> 
  <img data-src="./images/Image.jpg" alt="Image">
</picture>
```
