### PR TITLE
feat: configurable html elements and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ _With_ `parcel-transformer-html-datasrc`:
 
 `parcel-transformer-html-datasrc` is currently supporting the following data-attributes:
 
-- `data-src` on `ìmg`-tags
 - `data-srcset` on `ìmg`-tags
+
+Customizable pairs of HTML tags that contain a custom data-attribute such as:
+
 - `data-background-image` on `div`-tags
+- `data-src`, or `your-custom-data-tag` on `img`, or `your-specified-html-element` -tags
 
 Feel free to suggest more!
 
@@ -41,7 +44,7 @@ Feel free to suggest more!
 
 `npm i -D parcel-transformer-html-datasrc`
 
-At the root of your project, next to your `package.json`, add a `.parcelrc`file and paste the following code:
+At the root of your project, next to your `package.json`, add a `.parcelrc` file and paste the following code:
 
 ```json
 {
@@ -49,6 +52,19 @@ At the root of your project, next to your `package.json`, add a `.parcelrc`file 
   "transformers": {
     "*.html": ["parcel-transformer-html-datasrc", "..."]
   }
+}
+```
+
+To configure HTML elements with custom url attributes, at the root of your project, next to your `package.json` and your `.parcelrc` file, add a ` html-datasrc.config.json` file.
+
+- Json keys represent HTML elements.
+
+- Values can be a string or an array of strings that define corresponding custom data attributes.
+
+```json
+{
+  "img": ["data-src", "data-bp", "your-custom-data-attribute"],
+  "div": "data-background-image"
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,13 @@ const nullthrows = require('nullthrows')
 const { render } = require('posthtml-render')
 const semver = require('semver')
 const PostHTML = require('posthtml')
+const _ = require('lodash')
+
+// function customizer(objValue, srcValue) {
+//   if (_.isArray(objValue)) {
+//     return objValue.concat(srcValue)
+//   }
+// }
 
 module.exports = new Transformer({
   async loadConfig({ config }) {
@@ -25,7 +32,10 @@ module.exports = new Transformer({
     }
   },
 
-  async transform({ config, asset }) {
+  async transform({ config, asset, logger }) {
+    // must add logger to transform like ({ config, asset, logger}) if compile console.logs are desired
+    // logger.warn({ message: ` log message: ${config}` })
+
     const ast = nullthrows(await asset.getAST())
     let isDirty
     PostHTML().walk.call(ast.program, node => {
@@ -33,41 +43,104 @@ module.exports = new Transformer({
       if (!attrs) {
         return node
       }
+      // Default supported element and attribute pairs
+      const elemAndAttributes = {
+        div: ['data-bg', 'data-background-image', 'data-bg-hidpi', 'data-bg-multi'], // 'data-background-image-set' from lozad neds to be done
+        iframe: ['data-src'],
+        img: ['data-srcset', 'data-src', 'data-bp'],
+        picture: ['data-iesrc'],
+        source: ['data-src', 'data-srcset', 'srcset'],
+        video: ['data-src', 'data-poster'],
+      }
 
-      const customAttrsConfig = Object.keys(config).length === 0 ? undefined : config
+      // Optional user config file
+      const customElemAndAttrsConfig = Object.keys(config).length === 0 ? undefined : config
+      // Custom Attribute values filtered by current tag's attributes
+      const customAttrsValuesFiltered = customElemAndAttrsConfig[tag]
+        ? Object.values(customElemAndAttrsConfig[tag]).filter(item => Object.keys(attrs).includes(item))
+        : undefined
+      // logger.warn({ message: ` customAttrsfiltered: ${customAttrsValuesFiltered}` })
 
-      const customAttr =
-        customAttrsConfig?.[tag] && Array.isArray(customAttrsConfig[tag])
-          ? customAttrsConfig[tag].find(item => Object.keys(attrs).includes(item))
-          : customAttrsConfig?.[tag]
+      const areMultipleFilteredValues = customAttrsValuesFiltered ? /,/.test(customAttrsValuesFiltered) : undefined
+      const testObject = _.merge(elemAndAttributes, customElemAndAttrsConfig)
+      // const secondObject = new Set(testObject)
+      logger.warn({ message: ` testObject: ${Object.entries(testObject)}` })
 
-      // logger.warn({ message: `customAttrTest: ${Object.keys(config)} \n ${Object.keys(attrs)}` })
-      // must add logger to transform like ({ config, asset, logger})
+      // const customAttr =
+      //   customElemAndAttrsConfig[tag] && Array.isArray(customElemAndAttrsConfig[tag])
+      //     ? customElemAndAttrsConfig[tag].find(item => Object.keys(attrs).includes(item))
+      //     : customElemAndAttrsConfig[tag]
+      //     ? customElemAndAttrsConfig[tag]
+      //     : undefined
+      const regexInsideParen = /(?<=url\().*(?=\))/
+      // logger.warn({ message: ` tag: ${tag} \n attrs: ${regexInsideParen.test(Object.entries(attrs))}` })
 
       /*
-      if attrs contains 'url('
-      do...
+       *  Adds url dependency to attributes such as below data-bg-multi that contain
+       *  both multiple url() wrapped sources and other data
+       *
+       *   `<div
+       *     class="lazy"
+       *     data-bg-multi="
+       *       url(lazy-head.jpg),
+       *       url(lazy-body.jpg),
+       *       linear-gradient(#fff, #ccc)"
+       *   >...</div>`
+       *
+       */
+      const addUrlAndGradientAttrsDependency = item => {
+        const srcsets = attrs[item]
+          .trim()
+          .split(',')
+          .map(el => {
+            if (regexInsideParen.test(el)) {
+              const url = el.match(regexInsideParen)
+              const updatedUrl = asset.addURLDependency(url, {})
+              // logger.warn({ message: `\n mapitem: ${el}\n url:${url}\n updatedUrl: ${updatedUrl}`})
+              return el.replace(url, updatedUrl)
+            }
+            return el.trim()
+          })
+          .join(', ')
+        attrs[item] = srcsets
+      }
 
-      if attrs contains ','
-      do...
-
-      if attrs contains ',' && 'url('
-
-
-      */
-      if (customAttrsConfig && tag in customAttrsConfig && attrs[customAttr] != null) {
-        attrs[customAttr] = asset.addURLDependency(attrs[customAttr], {})
+      if (areMultipleFilteredValues) {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const item of customAttrsValuesFiltered) {
+          if (attrs[item] != null && regexInsideParen.test(attrs[item])) {
+            addUrlAndGradientAttrsDependency(item)
+          }
+        }
         isDirty = true
       }
 
-      if (tag === 'img' && attrs['data-srcset'] != null) {
-        const srcsets = attrs['data-srcset'].split(',').map(item => {
+      if (tag === 'img' && attrs['data-bp'] != null) {
+        const srcsets = attrs['data-bp'].split(',').map(item => {
           const [url, width] = item.trim().split(' ')
-          return `${asset.addURLDependency(url)} ${width}`
+          return width && url ? `${asset.addURLDependency(url)} ${width}` : asset.addURLDependency(url)
         })
-        attrs['data-srcset'] = srcsets.join(', ')
+        attrs['data-bp'] = srcsets.join(', ')
         isDirty = true
       }
+      // if (
+      //   !areMultipleFilteredValues &&
+      //   customElemAndAttrsConfig &&
+      //   tag in customElemAndAttrsConfig &&
+      //   attrs[customAttrsValuesFiltered] != null
+      // ) {
+      //   attrs[customAttrsValuesFiltered] = asset.addURLDependency(attrs[customAttrsValuesFiltered], {})
+      //   isDirty = true
+      // }
+
+      // if (tag === 'img' && attrs['data-srcset'] != null) {
+      //   const srcsets = attrs['data-srcset'].split(',').map(item => {
+      //     const [url, width] = item.trim().split(' ')
+      //     return `${asset.addURLDependency(url)} ${width}`
+      //   })
+      //   attrs['data-srcset'] = srcsets.join(', ')
+      //   isDirty = true
+      // }
 
       if (tag === 'div' && attrs['data-background-image'] != null) {
         attrs['data-background-image'] = asset.addURLDependency(attrs['data-background-image'], {})

--- a/index.js
+++ b/index.js
@@ -44,6 +44,17 @@ module.exports = new Transformer({
       // logger.warn({ message: `customAttrTest: ${Object.keys(config)} \n ${Object.keys(attrs)}` })
       // must add logger to transform like ({ config, asset, logger})
 
+      /*
+      if attrs contains 'url('
+      do...
+
+      if attrs contains ','
+      do...
+
+      if attrs contains ',' && 'url('
+
+
+      */
       if (customAttrsConfig && tag in customAttrsConfig && attrs[customAttr] != null) {
         attrs[customAttr] = asset.addURLDependency(attrs[customAttr], {})
         isDirty = true

--- a/index.js
+++ b/index.js
@@ -7,13 +7,8 @@ const PostHTML = require('posthtml')
 
 module.exports = new Transformer({
   async loadConfig({ config }) {
-    const { configFile } = await config.getConfig(['html-datasrc.config.json'])
-
-    if (configFile?.contents) {
-      // RENAME .contents to appropriate field
-      return configFile.contents
-    }
-    return {}
+    const { contents } = (await config.getConfig(['html-datasrc.config.json'])) || {}
+    return contents
   },
 
   canReuseAST({ ast }) {
@@ -38,15 +33,18 @@ module.exports = new Transformer({
       if (!attrs) {
         return node
       }
-      const customProps = config.contents
-      const customAttr = customProps[tag] ? customProps[tag[0]] : null
 
-      if (Object.prototype.hasOwnProperty.call(customProps, tag) && customAttr) {
-        attrs[customAttr] = asset.addURLDependency(attrs[customAttr], {})
-        isDirty = true
-      }
+      /*  *************** To Do *****************
+       *
+       *  duplicate key names not allowed so below code only works for a single custom attribute
+       *  add support for an array of custom attribut for each custom property
+       */
 
-      if (customProps[tag] && customAttr != null) {
+      const customProps = Object.keys(config).length === 0 ? undefined : config
+      const customAttr = customProps?.[tag]
+      // logger.warn({ message: `customProps: ${Object.keys(config)} \n ${customAttr}` })
+      // must add logger to transform like ({ config, asset, logger})
+      if (customProps && tag in customProps && attrs[customAttr] != null) {
         attrs[customAttr] = asset.addURLDependency(attrs[customAttr], {})
         isDirty = true
       }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const nullthrows = require('nullthrows')
 const { render } = require('posthtml-render')
 const semver = require('semver')
 const PostHTML = require('posthtml')
-// const _ = require('lodash')
 const R = require('ramda')
 
 module.exports = new Transformer({

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = new Transformer({
     }
   },
 
-  async transform({ config, asset, logger }) {
+  async transform({ config, asset }) {
     // must add logger to transform like ({ config, asset, logger}) if compile console.logs are desired
     // logger.warn({ message: ` log message: ${config}` })
 
@@ -73,8 +73,6 @@ module.exports = new Transformer({
           return width && url ? `${asset.addURLDependency(url)} ${width}` : asset.addURLDependency(url)
         })
         attrs[item] = srcsets.join(', ')
-        logger.warn({ message: `\nsrcsets: ${srcsets}` })
-
         isDirty = true
       }
 

--- a/index.js
+++ b/index.js
@@ -39,13 +39,16 @@ module.exports = new Transformer({
         return node
       }
       const customProps = config.contents
-      if (customProps) {
-        Object.entries(customProps).forEach(e => {
-          if (tag === e && attrs[e[0]] != null) {
-            attrs[e[0]] = asset.addURLDependency(attrs[e[0]], {})
-            isDirty = true
-          }
-        })
+      const customAttr = customProps[tag] ? customProps[tag[0]] : null
+
+      if (Object.prototype.hasOwnProperty.call(customProps, tag) && customAttr) {
+        attrs[customAttr] = asset.addURLDependency(attrs[customAttr], {})
+        isDirty = true
+      }
+
+      if (customProps[tag] && customAttr != null) {
+        attrs[customAttr] = asset.addURLDependency(attrs[customAttr], {})
+        isDirty = true
       }
 
       if (tag === 'img' && attrs['data-src'] != null) {

--- a/index.js
+++ b/index.js
@@ -34,23 +34,18 @@ module.exports = new Transformer({
         return node
       }
 
-      /*  *************** To Do *****************
-       *
-       *  duplicate key names not allowed so below code only works for a single custom attribute
-       *  add support for an array of custom attribut for each custom property
-       */
+      const customAttrsConfig = Object.keys(config).length === 0 ? undefined : config
 
-      const customProps = Object.keys(config).length === 0 ? undefined : config
-      const customAttr = customProps?.[tag]
-      // logger.warn({ message: `customProps: ${Object.keys(config)} \n ${customAttr}` })
+      const customAttr =
+        customAttrsConfig?.[tag] && Array.isArray(customAttrsConfig[tag])
+          ? customAttrsConfig[tag].find(item => Object.keys(attrs).includes(item))
+          : customAttrsConfig?.[tag]
+
+      // logger.warn({ message: `customAttrTest: ${Object.keys(config)} \n ${Object.keys(attrs)}` })
       // must add logger to transform like ({ config, asset, logger})
-      if (customProps && tag in customProps && attrs[customAttr] != null) {
-        attrs[customAttr] = asset.addURLDependency(attrs[customAttr], {})
-        isDirty = true
-      }
 
-      if (tag === 'img' && attrs['data-src'] != null) {
-        attrs['data-src'] = asset.addURLDependency(attrs['data-src'], {})
+      if (customAttrsConfig && tag in customAttrsConfig && attrs[customAttr] != null) {
+        attrs[customAttr] = asset.addURLDependency(attrs[customAttr], {})
         isDirty = true
       }
 

--- a/mock/html-datasrc.config.json
+++ b/mock/html-datasrc.config.json
@@ -1,0 +1,4 @@
+{
+  "img": "fakeprop",
+  "div": "fake-prop"
+}

--- a/mock/html-datasrc.config.json
+++ b/mock/html-datasrc.config.json
@@ -1,4 +1,4 @@
 {
-  "img": "fakeprop",
-  "div": "fake-prop"
+  "img": ["data-src", "data-bp", "data-does-not-exist"],
+  "div": "data-background-image"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "posthtml": "^0.16.1",
         "posthtml-parser": "^0.9.0",
         "posthtml-render": "^3.0.0",
+        "ramda": "^0.27.1",
         "semver": "^7.3.5"
       },
       "devDependencies": {
@@ -9276,6 +9277,11 @@
         }
       ]
     },
+    "node_modules/ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -16981,7 +16987,7 @@
         "eslint-plugin-import": "^2.23.4",
         "husky": "^6.0.0",
         "lint-staged": "^11.0.0",
-        "lodash": "*",
+        "lodash": "^4.17.21",
         "mocha": "^9.0.0",
         "mocha-lcov-reporter": "^1.3.0",
         "nullthrows": "^1.1.1",
@@ -16992,6 +16998,7 @@
         "posthtml-parser": "^0.9.0",
         "posthtml-render": "^3.0.0",
         "prettier": "^2.3.1",
+        "ramda": "*",
         "semver": "^7.3.5"
       },
       "dependencies": {
@@ -23947,6 +23954,11 @@
           "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
           "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
         },
+        "ramda": {
+          "version": "0.27.1",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+          "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+        },
         "randombytes": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -26415,6 +26427,11 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
-  "name": "parcel-transformer-html-datasrc",
+  "name": "parcel-transformer-html-datasrc-dabell",
   "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "dev": true,
   "packages": {
     "": {
-      "name": "parcel-transformer-html-datasrc",
+      "name": "parcel-transformer-html-datasrc-dabell",
       "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "^2.0.0",
+        "lodash": "^4.17.21",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.1",
         "posthtml-parser": "^0.9.0",
@@ -6696,8 +6697,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -16085,8 +16085,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -16982,6 +16981,7 @@
         "eslint-plugin-import": "^2.23.4",
         "husky": "^6.0.0",
         "lint-staged": "^11.0.0",
+        "lodash": "*",
         "mocha": "^9.0.0",
         "mocha-lcov-reporter": "^1.3.0",
         "nullthrows": "^1.1.1",
@@ -22010,8 +22010,7 @@
         "lodash": {
           "version": "4.17.21",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.camelcase": {
           "version": "4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "parcel-transformer-html-datasrc-dabell",
+  "name": "parcel-transformer-html-datasrc",
   "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "dev": true,
   "packages": {
     "": {
-      "name": "parcel-transformer-html-datasrc-dabell",
+      "name": "parcel-transformer-html-datasrc",
       "version": "1.1.5",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "parcel-transformer-html-datasrc",
+  "name": "parcel-transformer-html-datasrc-dabell",
   "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "dev": true,
   "packages": {
     "": {
-      "name": "parcel-transformer-html-datasrc",
+      "name": "parcel-transformer-html-datasrc-dabell",
       "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
@@ -846,9 +846,9 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0.tgz",
-      "integrity": "sha512-cADyFWaMlhDawQdraFt2TECpiD/DvQ76L+RK97X7sUj5b+cGY7fjrnWPKRVmog5+OoNlbmh1EO3FOLx5vuxzww==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.1.tgz",
+      "integrity": "sha512-pC9GmEUUB2UQ9epvE/H2wn0rb6hyF68QlpxppHZ9fxib/RxqGWDG1I3axR0cxZifRRZiMNnbk7HfmUB19KNTtA==",
       "dependencies": {
         "json-source-map": "^0.6.1",
         "nullthrows": "^1.1.1"
@@ -862,9 +862,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0.tgz",
-      "integrity": "sha512-v9+pXLtgc44+eIbNAs/SB2tyXKUv+5XF1f3TRsLJ44276e9ksa3Cstrs1EFxZtpi03UoXkXJQoJljGigb2bt8A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.1.tgz",
+      "integrity": "sha512-JRt5SkFS8/8r37o1DRKVtrWR1OZNN2pL548YsXVKBLN1b2ys36/+yKNObDuGB7DcOcIRngVs7xxv6+oodGyMlQ==",
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -964,12 +964,12 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0.tgz",
-      "integrity": "sha512-jpESL6m4tEGP+Yj/PZGb6ellrOx3irEIvSjbhwZBGoXaApqqvB352dLXrVJ/vyrmzj9YLNdm2rPWeZWkMDGgMA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.1.tgz",
+      "integrity": "sha512-gN2mdDnUkbN11hUIDBU+zlREsgp7zm42ZAsc0xwIdmlnsZY7wu2G3lNtkXSMlIPJPdRi6oE6vmaArQJfXjaAOg==",
       "dependencies": {
-        "@parcel/diagnostic": "^2.0.0",
-        "@parcel/events": "^2.0.0"
+        "@parcel/diagnostic": "^2.0.1",
+        "@parcel/events": "^2.0.1"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -11716,18 +11716,18 @@
       }
     },
     "@parcel/diagnostic": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0.tgz",
-      "integrity": "sha512-cADyFWaMlhDawQdraFt2TECpiD/DvQ76L+RK97X7sUj5b+cGY7fjrnWPKRVmog5+OoNlbmh1EO3FOLx5vuxzww==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.1.tgz",
+      "integrity": "sha512-pC9GmEUUB2UQ9epvE/H2wn0rb6hyF68QlpxppHZ9fxib/RxqGWDG1I3axR0cxZifRRZiMNnbk7HfmUB19KNTtA==",
       "requires": {
         "json-source-map": "^0.6.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/events": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0.tgz",
-      "integrity": "sha512-v9+pXLtgc44+eIbNAs/SB2tyXKUv+5XF1f3TRsLJ44276e9ksa3Cstrs1EFxZtpi03UoXkXJQoJljGigb2bt8A=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.1.tgz",
+      "integrity": "sha512-JRt5SkFS8/8r37o1DRKVtrWR1OZNN2pL548YsXVKBLN1b2ys36/+yKNObDuGB7DcOcIRngVs7xxv6+oodGyMlQ=="
     },
     "@parcel/fs": {
       "version": "2.0.0",
@@ -11785,12 +11785,12 @@
       }
     },
     "@parcel/logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0.tgz",
-      "integrity": "sha512-jpESL6m4tEGP+Yj/PZGb6ellrOx3irEIvSjbhwZBGoXaApqqvB352dLXrVJ/vyrmzj9YLNdm2rPWeZWkMDGgMA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.1.tgz",
+      "integrity": "sha512-gN2mdDnUkbN11hUIDBU+zlREsgp7zm42ZAsc0xwIdmlnsZY7wu2G3lNtkXSMlIPJPdRi6oE6vmaArQJfXjaAOg==",
       "requires": {
-        "@parcel/diagnostic": "^2.0.0",
-        "@parcel/events": "^2.0.0"
+        "@parcel/diagnostic": "^2.0.1",
+        "@parcel/events": "^2.0.1"
       }
     },
     "@parcel/markdown-ansi": {
@@ -17641,18 +17641,18 @@
           }
         },
         "@parcel/diagnostic": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0.tgz",
-          "integrity": "sha512-cADyFWaMlhDawQdraFt2TECpiD/DvQ76L+RK97X7sUj5b+cGY7fjrnWPKRVmog5+OoNlbmh1EO3FOLx5vuxzww==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.1.tgz",
+          "integrity": "sha512-pC9GmEUUB2UQ9epvE/H2wn0rb6hyF68QlpxppHZ9fxib/RxqGWDG1I3axR0cxZifRRZiMNnbk7HfmUB19KNTtA==",
           "requires": {
             "json-source-map": "^0.6.1",
             "nullthrows": "^1.1.1"
           }
         },
         "@parcel/events": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0.tgz",
-          "integrity": "sha512-v9+pXLtgc44+eIbNAs/SB2tyXKUv+5XF1f3TRsLJ44276e9ksa3Cstrs1EFxZtpi03UoXkXJQoJljGigb2bt8A=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.1.tgz",
+          "integrity": "sha512-JRt5SkFS8/8r37o1DRKVtrWR1OZNN2pL548YsXVKBLN1b2ys36/+yKNObDuGB7DcOcIRngVs7xxv6+oodGyMlQ=="
         },
         "@parcel/fs": {
           "version": "2.0.0",
@@ -17710,12 +17710,12 @@
           }
         },
         "@parcel/logger": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0.tgz",
-          "integrity": "sha512-jpESL6m4tEGP+Yj/PZGb6ellrOx3irEIvSjbhwZBGoXaApqqvB352dLXrVJ/vyrmzj9YLNdm2rPWeZWkMDGgMA==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.1.tgz",
+          "integrity": "sha512-gN2mdDnUkbN11hUIDBU+zlREsgp7zm42ZAsc0xwIdmlnsZY7wu2G3lNtkXSMlIPJPdRi6oE6vmaArQJfXjaAOg==",
           "requires": {
-            "@parcel/diagnostic": "^2.0.0",
-            "@parcel/events": "^2.0.0"
+            "@parcel/diagnostic": "^2.0.1",
+            "@parcel/events": "^2.0.1"
           }
         },
         "@parcel/markdown-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "parcel-transformer-html-datasrc-dabell",
+  "name": "parcel-transformer-html-datasrc",
   "version": "1.1.5",
   "description": "A Parcel 2.x Plugin to parse data-src and data-srcset attributes on html image-tags",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "^2.0.0",
+    "lodash": "^4.17.21",
     "nullthrows": "^1.1.1",
     "posthtml": "^0.16.1",
     "posthtml-parser": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "posthtml": "^0.16.1",
     "posthtml-parser": "^0.9.0",
     "posthtml-render": "^3.0.0",
+    "ramda": "^0.27.1",
     "semver": "^7.3.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "parcel-transformer-html-datasrc",
+  "name": "parcel-transformer-html-datasrc-dabell",
   "version": "1.1.5",
   "description": "A Parcel 2.x Plugin to parse data-src and data-srcset attributes on html image-tags",
   "main": "index.js",


### PR DESCRIPTION
I was very happy to find your package a couple of days ago. 

This pull request adds parcel's config load method to point to an optional JSON configuration file in a user's project root directory. The json configuration file may contain key: value pairs of HTML elements and custom data attributes `either as a string or an array of strings` for the basic `addURLDependency()` method.

If an array is specified in the configuration json, it will only change the first found custom data-attribute per HTML element 

See the added `mock/html-datasrc.config.json` for configuration

I unfortunately have not learned how to write tests yet to add those as well. 