### PR TITLE
Bugfixes: assignment errors and regex update

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = new Transformer({
           'data-bg-multi',
           'data-background-image-set',
           'data-bg-multi-hidpi',
-        ], // 'data-background-image-set' from lozad neds to be done
+        ],
         iframe: ['data-src'],
         img: ['data-srcset', 'data-src', 'data-bp'],
         picture: ['data-iesrc'],

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = new Transformer({
     }
   },
 
-  async transform({ config, asset, logger }) {
+  async transform({ config, asset }) {
     // must add logger to transform like ({ config, asset, logger}) if compile console.logs are desired
     // logger.warn({ message: ` log message: ${config}` })
 
@@ -38,8 +38,16 @@ module.exports = new Transformer({
         return node
       }
       // Default supported element and attribute pairs
+      // Must be arrays
       const elemAndAttributes = {
-        div: ['data-bg', 'data-background-image', 'data-bg-hidpi', 'data-bg-multi', 'data-background-image-set'], // 'data-background-image-set' from lozad neds to be done
+        div: [
+          'data-bg',
+          'data-background-image',
+          'data-bg-hidpi',
+          'data-bg-multi',
+          'data-background-image-set',
+          'data-bg-multi-hidpi',
+        ], // 'data-background-image-set' from lozad neds to be done
         iframe: ['data-src'],
         img: ['data-srcset', 'data-src', 'data-bp'],
         picture: ['data-iesrc'],
@@ -50,13 +58,12 @@ module.exports = new Transformer({
       // Optional user config file
       const customElemAndAttrsConfig = config || undefined
 
-      logger.warn({ message: `customElemAndAttrsConfig: ${customElemAndAttrsConfig}` })
-
       const mergedConfigs = customElemAndAttrsConfig
         ? R.mergeWith(R.concat, elemAndAttributes, customElemAndAttrsConfig)
         : elemAndAttributes
 
-      const currentTagAttrs = [...new Set(mergedConfigs?.[tag])]
+      const currentTagAttrs = R.length(mergedConfigs[tag]) > 1 ? [...new Set(mergedConfigs[tag])] : mergedConfigs[tag]
+
       const areMultipleFilteredValues = currentTagAttrs ? /,/.test(currentTagAttrs) : undefined
 
       const regexInsideParen = /(?<=url\().*(?=\))/
@@ -94,15 +101,13 @@ module.exports = new Transformer({
           .map(el => {
             if (regexQuoteInsideParen.test(el)) {
               const url = el.match(regexQuoteInsideParen)
-              logger.warn({ message: `quoteregex el: ${url}` })
               const updatedUrl = asset.addURLDependency(url, {})
-              return el.replace(url, updatedUrl)
+              return el.replace(regexQuoteInsideParen, updatedUrl)
             }
             if (regexInsideParen.test(el)) {
               const url = el.match(regexInsideParen)
-              logger.warn({ message: `nonquoteregex el: ${url}` })
               const updatedUrl = asset.addURLDependency(url, {})
-              return el.replace(url, updatedUrl)
+              return el.replace(regexInsideParen, updatedUrl)
             }
             return el.trim()
           })
@@ -129,9 +134,9 @@ module.exports = new Transformer({
           regexQuoteInsideParen.test(attrs[currentTagAttrs]) ||
           undefined
         if (attrs[currentTagAttrs] != null && isRegexUrl) {
-          addUrlAndGradientAttrsDependency(attrs[currentTagAttrs])
+          addUrlAndGradientAttrsDependency(currentTagAttrs)
         } else if (attrs[currentTagAttrs] != null) {
-          addBasicUrlDependency(attrs[currentTagAttrs])
+          addBasicUrlDependency(currentTagAttrs)
         }
       }
 


### PR DESCRIPTION
I found some not so great assignment errors while updating the regex matches to handle tags like `'data-background-image-set'` with quote `url('...')` sources.

This pull request fixes those bugs and updates the regex matching.

This pull request also fixes a crash when a user config file is not present. I changed to much with the prior version and somehow broke that too. Oops. Hopefully there is not more to come.

There is still one bug with this build and the prior build related to regex match and replace of said urls. They work as expected when the sources are found at compile time but if the sources cannot be found:

This compiles correctly to local image:
```
<div data-background-image-set="url('./images/gallery/kitchens/thumbs/kitch009-thumb.jpg') 1x"
```

This throws a compile error: 
```
<div data-background-image-set="url('./images/gallery/kitchens/thumbs/kitch009-thumb.jpg') 1x"
```

The error should like like:
```
@parcel/core: Failed to resolve './images/gallery/kitchens/kitch001.jp' from './src/portfolio.html'
@parcel/resolver-default: Cannot load file './images/gallery/kitchens/kitch001.jp' in './src'.
```
Instead it throws this error...
```
Error: dependency.specifier.match is not a function
TypeError: dependency.specifier.match is not a function
  at ResolverRunner.resolve (\node_modules\@parcel\core\lib\requests\PathRequest.js:179:38)
  at async Object.run (\node_modules\@parcel\core\lib\requests\PathRequest.js:104:16)
  at async RequestTracker.runRequest (\node_modules\@parcel\core\lib\RequestTracker.js:721:20)
  at async AssetGraphBuilder.runPathRequest (\node_modules\@parcel\core\lib\requests\AssetGraphRequest.js:762:18)
  at async PromiseQueue._runFn (\node_modules\@parcel\utils\lib\PromiseQueue.js:88:7)
  at async PromiseQueue._next (\node_modules\@parcel\utils\lib\PromiseQueue.js:75:5)
```

Maybe a second set of eyes can sort that bug out. If not, I can ask the parcel team.